### PR TITLE
3.18 and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+data/glib-2.0/schemas/gschemas.compiled:
+	glib-compile-schemas data/glib-2.0/schemas

--- a/data/glib-2.0/schemas/.gitignore
+++ b/data/glib-2.0/schemas/.gitignore
@@ -1,0 +1,1 @@
+gschemas.compiled

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16"],
+    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18"],
     "uuid": "shade-inactive-windows@hepaajan.iki.fi",
     "name": "Shade Inactive Windows",
     "description": "Make inactive windows darker",


### PR DESCRIPTION
Mark 3.18 as supported, and add a Makefile so people don't have to hunt error logs for the missing schemata.

Thanks for this fork!
